### PR TITLE
Added distance-based crosshair scaling option

### DIFF
--- a/cvarinfo.txt
+++ b/cvarinfo.txt
@@ -10,9 +10,11 @@ user bool pc_flip_x = false;
 user bool pc_disable_slot_1    = false;
 user bool pc_disable_not_ready = false;
 user bool pc_disable_no_weapon = true;
+user bool pc_distance_scale = true;
 
 user bool pc_target_health = false;
 
 // Precise External Interface //////////////////////////////////////////////////
 
 user float pc_y;
+user float pc_scale;

--- a/language.txt
+++ b/language.txt
@@ -18,6 +18,7 @@ PC_SLOT_1   = "Disable on slot 1";
 PC_NOT_READY = "Disable when weapon is not ready";
 PC_NO_WEAPON = "Disable when there is no weapon";
 PC_TARGET_COLOR = "Show target color instead of player";
+PC_DISTANCE_SCALE = "Scale crosshair by distance";
 
 // Crosshair names /////////////////////////////////////////////////////////////
 

--- a/menudef.txt
+++ b/menudef.txt
@@ -39,6 +39,7 @@ OptionMenu pc_Menu
   Option     "$PC_SLOT_1"          , pc_disable_slot_1    , YesNo
   Option     "$PC_NOT_READY"       , pc_disable_not_ready , YesNo
   Option     "$PC_NO_WEAPON"       , pc_disable_no_weapon , YesNo
+  Option     "$PC_DISTANCE_SCALE"  , pc_distance_scale    , YesNo
 
   StaticText ""
   Option     "$PC_TARGET_COLOR"    , pc_target_health     , YesNo

--- a/zscript/pc_event_handler.zs
+++ b/zscript/pc_event_handler.zs
@@ -351,6 +351,17 @@ class pc_EventHandler : EventHandler
     _externalY.SetFloat(y);
   }
 
+  private play
+  void setExternalScale (PlayerInfo player, double scale) const
+  {
+    if (_externalScale == NULL)
+    {
+      _externalScale = Cvar.GetCVar("pc_scale", player);
+    }
+
+    _externalScale.SetFloat(scale);
+  }
+
 // private: ////////////////////////////////////////////////////////////////////
 
   private ui static
@@ -461,12 +472,14 @@ class pc_EventHandler : EventHandler
   private ui
   double GetDistanceScale(double minDist = 0, double maxDist = 1024, double minScale = 1.0, double maxScale = 4.0)
   {
-    if (_distToTarget >= maxDist)
+    double scale = minScale;
+    if (_distToTarget < maxDist)
     {
-      return minScale;
+      double dist = Clamp(_distToTarget, minDist, maxDist);
+      scale = LinearMap(dist, maxdist, mindist, minscale, maxscale);
     }
-    double dist = Clamp(_distToTarget, minDist, maxDist);
-    return LinearMap(dist, maxdist, mindist, minscale, maxscale);
+    setExternalScale(players[consoleplayer], scale);
+    return scale;
   }
     
 
@@ -484,6 +497,7 @@ class pc_EventHandler : EventHandler
   private transient bool   _isPrepared;
   private transient Cvar   _cvarRenderer;
   private transient Cvar   _externalY;
+  private transient Cvar   _externalScale;
 
   private pc_Le_ProjScreen _projection;
   private pc_Le_GlScreen   _glProjection;

--- a/zscript/pc_event_handler.zs
+++ b/zscript/pc_event_handler.zs
@@ -138,7 +138,7 @@ class pc_EventHandler : EventHandler
     double height = textureSize.y * size;
     if (_settings.isScaledByDistance())
     {
-      double distFac = GetDistanceScale(0, 512, 1.0, 4.0);
+      double distFac = GetDistanceScale(0, 512);
       width *= distFac;
       height *= distFac;
     }
@@ -466,6 +466,7 @@ class pc_EventHandler : EventHandler
       return minScale;
     }
     double dist = Clamp(_distToTarget, minDist, maxDist);
+    return LinearMap(dist, maxdist, mindist, minscale, maxscale);
   }
     
 

--- a/zscript/settings/pc_settings.zs
+++ b/zscript/settings/pc_settings.zs
@@ -33,6 +33,7 @@ class pc_Settings : pc_SettingsPack
   bool isDisabledOnSlot1   () { checkInit(); return _disableOnSlot1   .value(); }
   bool isDisabledOnNotReady() { checkInit(); return _disableOnNotReady.value(); }
   bool isDisabledOnNoWeapon() { checkInit(); return _disableNoWeapon  .value(); }
+  bool isScaledByDistance  () { checkInit(); return _distanceScale    .value(); }
 
   bool isTargetHealth() { checkInit(); return _targetHealth.value(); }
 
@@ -51,6 +52,7 @@ class pc_Settings : pc_SettingsPack
     push(_disableOnNotReady = newBoolSetting("pc_disable_not_ready"));
     push(_disableNoWeapon   = newBoolSetting("pc_disable_no_weapon"));
     push(_targetHealth      = newBoolSetting("pc_target_health"    ));
+    push(_distanceScale     = newBoolSetting("pc_distance_scale"   ));
 
     _isInitialized = true;
   }
@@ -69,6 +71,7 @@ class pc_Settings : pc_SettingsPack
   private pc_BoolSetting _disableOnNotReady;
   private pc_BoolSetting _disableNoWeapon;
   private pc_BoolSetting _targetHealth;
+  private pc_BoolSetting _distanceScale;
 
   private PlayerInfo     _player;
   private transient bool _isInitialized;


### PR DESCRIPTION
This adds an option to allow the crosshair to grow with distance.

Also, removed LAF flags being passed to LineTrace. I assume this is an oversight and at some point LineAttack was used instead of LineTrace. LineTrace does not utilize LAF flags, and this could lead to wrong flags being unintentionally passed to LineTrace.